### PR TITLE
Fix isolate script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime
 
 RUN apt-get update
-RUN apt-get install --fix-missing -y -q --no-install-recommends libgomp1 ffmpeg libsm6 libxext6 pdftohtml git ninja-build g++ qpdf pandoc
+RUN apt-get install --fix-missing -y -q --no-install-recommends libgomp1 ffmpeg libsm6 libxext6 pdftohtml git ninja-build g++ qpdf pandoc iputils-ping curl
 
 RUN mkdir -p /app/src
 RUN mkdir -p /app/models

--- a/strict_isolate.sh
+++ b/strict_isolate.sh
@@ -34,10 +34,10 @@ done
 
 # Only two rules needed:
 # 1. Allow incoming traffic to the specified port
-iptables -A DOCKER-USER -p tcp --dport "$CONTAINER_PORT" -d "$CONTAINER_IP" -j ACCEPT
+iptables -I DOCKER-USER -p tcp --dport "$CONTAINER_PORT" -d "$CONTAINER_IP" -j ACCEPT
 
 # 2. Block EVERYTHING else from this container
-iptables -A DOCKER-USER -s "$CONTAINER_IP" -j DROP
+iptables -I DOCKER-USER -s "$CONTAINER_IP" -j DROP
 
 echo "Strict container isolation applied:"
 echo " - Container: $CONTAINER_NAME_OR_ID"


### PR DESCRIPTION
By changing the -A (append) flag to the -I (insert), the rules are now inserted at the beginning of the DOCKER-USER chain, ensuring they are processed before the RETURN rule. This ordering ensures that the specific allow and deny rules are evaluated first, before the broad RETURN rule can match the traffic.

Also included curl and ping utilities installation in the Dockerfile for testing the isolation